### PR TITLE
Fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+Here are useful commands.
+
+## Developing locally
+
+* `TARGET=firefox gulp watch`
+* `TARGET=chrome gulp watch`

--- a/manifests/chrome/manifest.json
+++ b/manifests/chrome/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Dnote",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Capture your coding knowledge without leaving the browser.",
   "icons": {
     "16": "images/iconx16.png",

--- a/manifests/firefox/manifest.json
+++ b/manifests/firefox/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Dnote",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Capture your coding knowledge without leaving the browser.",
   "applications": {
     "gecko": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "author": "Sung Won Cho <mikeswcho@gmail.com> (https://sung.io/)",
   "license": "MIT",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "dependencies": {
     "classnames": "^2.2.5",
     "lodash": "^4.17.5",

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -17,7 +17,7 @@ function filterState(state) {
 }
 
 function syncToStorage(state) {
-  chrome.storage.sync.set({ state: filterState(state) }, () => {
+  chrome.storage.local.set({ state: filterState(state) }, () => {
     console.log("synced");
   });
 }

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -12,10 +12,11 @@ const port = chrome.runtime.connect();
 
 const appContainer = document.getElementById("app");
 
-chrome.storage.sync.get("state", items => {
+chrome.storage.local.get("state", items => {
   if (chrome.runtime.lastError) {
-    appContainer.innerText = `Failed to retrieve previous app state ${chrome
-      .runtime.lastError.message}`;
+    appContainer.innerText = `Failed to retrieve previous app state ${
+      chrome.runtime.lastError.message
+    }`;
     return;
   }
 

--- a/src/scripts/popup.js
+++ b/src/scripts/popup.js
@@ -48,7 +48,7 @@ chrome.storage.local.get("state", items => {
 
   // persist state on popup close
   window.addEventListener(
-    "unload",
+    "blur",
     function(event) {
       const state = store.getState();
       const bpWindow = chrome.extension.getBackgroundPage();


### PR DESCRIPTION
Fixes

* In Firefox 61, callback to `onblur` cannot access `chrome.extension` object. (`Error: Expected an object as the target scope`)
* On Chrome, sometimes we get `QUOTA_BYTES_PER_ITEM quota exceeded` on blur.